### PR TITLE
Add low-resource config for single-VM usage

### DIFF
--- a/config/config.vagrant.artifactory.json
+++ b/config/config.vagrant.artifactory.json
@@ -21,7 +21,7 @@
             "url": "http://158.85.240.154:31374/artifactory/basho-artifactory-cloud-rmf/ubuntu-14.04/scheduler/1.0-rc2-0.26/riak_mesos_scheduler-1.0.rc2-mesos-0.26-ubuntu-14.04-amd64.tar.gz",
             "cpus": 0.5,
             "mem": 256.0,
-            "constraints": [["hostname", "UNIQUE"]]
+            "constraints": []
         },
         "executor": {
             "url": "http://158.85.240.154:31374/artifactory/basho-artifactory-cloud-rmf/ubuntu-14.04/executor/1.0-rc2-0.26/riak_mesos_executor-1.0.rc2-mesos-0.26-ubuntu-14.04.tar.gz",

--- a/config/config.vagrant.artifactory.json
+++ b/config/config.vagrant.artifactory.json
@@ -1,0 +1,46 @@
+{
+    "riak": {
+        "framework-name": "riak",
+        "hostname": "riak.marathon.mesos",
+        "marathon": "marathon.mesos:8080",
+        "master": "leader.mesos:5050",
+        "zk": "leader.mesos:2181",
+        "user": "root",
+        "role": "riak",
+        "auth-principal": "riak",
+        "auth-provider": "",
+        "auth-secret-file": "",
+        "instances": 1,
+        "failover-timeout": 10000.0,
+        "healthcheck-grace-period-seconds": 300,
+        "healthcheck-interval-seconds": 60,
+        "healthcheck-timeout-seconds": 20,
+        "healthcheck-max-consecutive-failures": 5,
+        "constraints": [],
+        "scheduler": {
+            "url": "http://158.85.240.154:31374/artifactory/basho-artifactory-cloud-rmf/ubuntu-14.04/scheduler/1.0-rc2-0.26/riak_mesos_scheduler-1.0.rc2-mesos-0.26-ubuntu-14.04-amd64.tar.gz",
+            "cpus": 0.5,
+            "mem": 256.0,
+            "constraints": [["hostname", "UNIQUE"]]
+        },
+        "executor": {
+            "url": "http://158.85.240.154:31374/artifactory/basho-artifactory-cloud-rmf/ubuntu-14.04/executor/1.0-rc2-0.26/riak_mesos_executor-1.0.rc2-mesos-0.26-ubuntu-14.04.tar.gz",
+            "cpus": 0.1,
+            "mem": 512.0
+        },
+        "node": {
+            "url": "http://riak-tools.s3.amazonaws.com/riak/2.1/2.1.3/ubuntu/14.04/riak-2.1.3-amd64.tar.gz",
+            "patches-url": "http://158.85.240.154:31374/artifactory/basho-artifactory-cloud-rmf/ubuntu-14.04/executor/1.0-rc2-0.26/riak_erlpmd_patches-1.0.rc2-mesos-0.26-ubuntu-14.04.tar.gz",
+            "explorer-url": "http://158.85.240.154:31374/artifactory/basho-artifactory-cloud-rmf-cache/ubuntu-14.04/riak-explorer/0.3.0-5-g6e2827c-0.28/riak_explorer-0.3.0.patch-ubuntu-14.04-amd64.tar.gz",
+            "cpus": 0.25,
+            "mem": 512.0,
+            "disk": 1000.0
+        },
+        "director": {
+            "url": "http://158.85.240.154:31374/artifactory/basho-artifactory-cloud-rmf/ubuntu-14.04/director/1.0-rc1/riak_mesos_director-1.0.rc1-ubuntu-14.04.tar.gz",
+            "use-public": false,
+            "cpus": 0.5,
+            "mem": 256.0
+        }
+    }
+}

--- a/config/config.vagrant.github.json
+++ b/config/config.vagrant.github.json
@@ -20,7 +20,7 @@
         "scheduler": {
             "url": "https://github.com/basho-labs/riak-mesos-scheduler/releases/download/1.0-rc2/riak_mesos_scheduler-1.0.rc2-ubuntu-14.04-amd64.tar.gz",
             "cpus": 0.5,
-            "mem": 2048.0,
+            "mem": 256.0,
             "constraints": [["hostname", "UNIQUE"]]
         },
         "executor": {

--- a/config/config.vagrant.github.json
+++ b/config/config.vagrant.github.json
@@ -1,0 +1,46 @@
+{
+    "riak": {
+        "framework-name": "riak",
+        "hostname": "riak.marathon.mesos",
+        "marathon": "marathon.mesos:8080",
+        "master": "leader.mesos:5050",
+        "zk": "leader.mesos:2181",
+        "user": "root",
+        "role": "riak",
+        "auth-principal": "riak",
+        "auth-provider": "",
+        "auth-secret-file": "",
+        "instances": 1,
+        "failover-timeout": 10000.0,
+        "healthcheck-grace-period-seconds": 300,
+        "healthcheck-interval-seconds": 60,
+        "healthcheck-timeout-seconds": 20,
+        "healthcheck-max-consecutive-failures": 5,
+        "constraints": [],
+        "scheduler": {
+            "url": "https://github.com/basho-labs/riak-mesos-scheduler/releases/download/1.0-rc2/riak_mesos_scheduler-1.0.rc2-ubuntu-14.04-amd64.tar.gz",
+            "cpus": 0.5,
+            "mem": 2048.0,
+            "constraints": [["hostname", "UNIQUE"]]
+        },
+        "executor": {
+            "url": "https://github.com/basho-labs/riak-mesos-executor/releases/download/1.0-rc2/riak_mesos_executor-1.0.rc2-ubuntu-14.04-amd64.tar.gz",
+            "cpus": 0.1,
+            "mem": 512.0
+        },
+        "node": {
+            "url": "http://riak-tools.s3.amazonaws.com/riak/2.1/2.1.3/ubuntu/14.04/riak-2.1.3-amd64.tar.gz",
+            "patches-url": "https://github.com/basho-labs/riak-mesos-executor/releases/download/1.0-rc2/riak_erlpmd_patches-1.0.rc2-ubuntu-14.04-amd64.tar.gz",
+            "explorer-url": "https://github.com/basho-labs/riak_explorer/releases/download/0.3.0/riak_explorer-0.3.0.patch-ubuntu-trusty-amd64.tar.gz",
+            "cpus": 0.25,
+            "mem": 512.0,
+            "disk": 1000.0
+        },
+        "director": {
+            "url": "https://github.com/basho-labs/riak-mesos-director/releases/download/1.0-rc1/riak_mesos_director-1.0.rc1-ubuntu-14.04-amd64.tar.gz",
+            "use-public": false,
+            "cpus": 0.5,
+            "mem": 256.0
+        }
+    }
+}

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -27,13 +27,9 @@ To build the full framework (including a copy of Riak-KV - see `RIAK_TAG` in Mak
 # Build all RMF packages locally
 # This will take some time to complete as it builds each component
 cd /vagrant/ && make dev
-# Generate the config files
-make config
-cd tools/riak-mesos-tools
-# Make the appropriate directory and install the generated config.json for `riak-mesos`
-sudo mkdir -p /etc/riak-mesos
-sudo chown -R vagrant:vagrant /etc/riak-mesos
-cp config/config.local.json /etc/riak-mesos/config.json
+# Use a pre-made config file appropriate for this vagrant environment
+mkdir -p /etc/riak-mesos
+ln -nsf /vagrant/config/config.vagrant.artifactory.json /etc/riak-mesos/config.json
 ```
 
 Test with `riak-mesos-tools`:


### PR DESCRIPTION
This adds a couple of sample configs (one pulls artifacts from artifactory, the other from github) that use only the bare minimum resources. With the default vagrant setup, this should allow at least a 5-node cluster to be started.

Also add a little note in DEVELOPMENT.md on how to use this config.
